### PR TITLE
make robust to any future fix to ticket presentation

### DIFF
--- a/scripts/cve-2020-13777.bro
+++ b/scripts/cve-2020-13777.bro
@@ -16,7 +16,7 @@ redef record SSL::Info += {
 
 event ssl_session_ticket_handshake(c: connection, ticket_lifetime_hint: count, ticket: string)
 	{
-	if ( /^..\x00{16}.../ in ticket && |ticket| > 56 && bytestring_to_count(sub_bytes(ticket, 35, 2))+56 == |ticket| )
+	if ( /^.{0,3}\x00{16}.../ in ticket && |ticket| > 56 && bytestring_to_count(sub_bytes(ticket, 35, 2))+56 == |ticket| )
 		NOTICE([$note=CVE_2020_13777_Server, $conn=c, $msg="Server potentially vulnerable to CVE-2020-13777 detected", $identifier=cat(c$id$orig_h)]);
 	}
 


### PR DESCRIPTION
The ticket length is currently prepended to the ticket that ssl_session_ticket_handshake presents.
This change will mean that if the bug is fixed in the future in mainstream zeek, this script will continue to work.